### PR TITLE
fix a-simple-graphql-server.md

### DIFF
--- a/text/understanding-graphql/a-simple-graphql-server.md
+++ b/text/understanding-graphql/a-simple-graphql-server.md
@@ -105,7 +105,7 @@ What happens when we attempt to query for a user that doesn’t exist? Does it r
 
 ```sh
 $ curl -X POST -H "Content-Type:application/json" \
->     -d '{"query": "{user(id: \"123\"){_id username}}"}' \
+>     -d '{"query": "{user(id: \"abc\"){_id username}}"}' \
 >     http://localhost:3000/graphql
 {"data":{"user":null}}
 ```

--- a/text/understanding-graphql/a-simple-graphql-server.md
+++ b/text/understanding-graphql/a-simple-graphql-server.md
@@ -94,7 +94,7 @@ We have a couple of options if we want to run this query and get the data back f
 
 ```sh
 $ curl -X POST -H "Content-Type:application/json" \
->     -d '{"query": "{user(id: \"123\"){_id username}}"}' \`
+>     -d '{"query": "{user(id: \"123\"){_id username}}"}' \
 >     http://localhost:3000/graphql
 {"data":{"user":{"_id":"123","username":"jeresig"}}}
 ```


### PR DESCRIPTION
- Perhaps the ``` ` ```  is an unnecessary string
- expect a response equivalent to a 404, so we need to specify a non-existent id