### PR TITLE
Fix syntax of `@deprecated` directive

### DIFF
--- a/text/type-system/directives.md
+++ b/text/type-system/directives.md
@@ -60,6 +60,6 @@ type Direction {
 type User {
   id: Int!
   name: String
-  fullName: String @deprecated("Use `name` instead")
+  fullName: String @deprecated(reason: "Use `name` instead")
 }
 ```


### PR DESCRIPTION
The example didn't include the name of the argument (`reason`).